### PR TITLE
Simplify RIRecord and style, header, type adjustments

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/annotations/RIScaleType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/annotations/RIScaleType.java
@@ -1,13 +1,38 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.mzmine.datamodel.features.types.annotations;
 
 import io.github.mzmine.datamodel.features.types.abstr.StringType;
 import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
-import javafx.util.StringConverter;
-import javafx.util.converter.DefaultStringConverter;
 import org.jetbrains.annotations.NotNull;
 
-// This records the file containing the straight-chain alkane retention times used to calculate the scale
-
+/**
+ * This records the file name containing the straight-chain alkane retention times used to calculate
+ * the scale
+ */
 public class RIScaleType extends StringType implements AnnotationType {
 
   public String fromString(String s) {

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIDiffType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIDiffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,24 +25,15 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.SimpleRowBinding;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import static io.github.mzmine.datamodel.features.types.DataTypes.get;
+import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.DIFFERENCE;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-import java.text.NumberFormat;
-import java.util.List;
-
-import static io.github.mzmine.datamodel.features.types.DataTypes.get;
-import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.*;
-
 /**
- * Retention index type
- * This is frequently rounded, because everyone uses rounded versions
- * Rounding is therefore necessary for the endpoints of ranges to be placed at integer values
+ * Retention index difference from calculated to measured type
  */
 public class RIDiffType extends RIType {
 
@@ -50,20 +41,19 @@ public class RIDiffType extends RIType {
   @Override
   public String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ri_diff";
+    return "retention_index_diff";
   }
 
   @Override
   public @NotNull String getHeaderString() {
-    return "RI difference";
+    return "ΔRI";
   }
 
   @NotNull
   @Override
   public List<RowBinding> createDefaultRowBindings() {
-    return List.of(
-        new SimpleRowBinding(this, get(RIType.class), RANGE)
-    );
+    // calculates the difference between the min and max value in all features
+    return List.of(new SimpleRowBinding(this, get(RIType.class), DIFFERENCE));
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIMaxType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIMaxType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,24 +25,16 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.SimpleRowBinding;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
-import org.jetbrains.annotations.NotNull;
-
-import java.text.NumberFormat;
-import java.util.List;
-
 import static io.github.mzmine.datamodel.features.types.DataTypes.get;
-import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.AVERAGE;
 import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.MAX;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Retention index type
- * This is frequently rounded, because everyone uses rounded versions
- * Rounding is therefore necessary for the endpoints of ranges to be placed at integer values
  */
 public class RIMaxType extends IntegerType {
 
@@ -50,30 +42,18 @@ public class RIMaxType extends IntegerType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ri_max";
-  }
-
-  @Override
-  public NumberFormat getFormat() {
-    return DEFAULT_FORMAT;
-  }
-
-  @Override
-  public NumberFormat getExportFormat() {
-    return DEFAULT_FORMAT;
+    return "retention_index_max";
   }
 
   @Override
   public @NotNull String getHeaderString() {
-    return "Max RI";
+    return "RI (max)";
   }
 
   @NotNull
   @Override
   public List<RowBinding> createDefaultRowBindings() {
-    return List.of(
-        new SimpleRowBinding(this, get(RIType.class), MAX)
-    );
+    return List.of(new SimpleRowBinding(this, get(RIType.class), MAX));
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIMinType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIMinType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,24 +25,15 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.SimpleRowBinding;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
-import org.jetbrains.annotations.NotNull;
-
-import java.text.NumberFormat;
-import java.util.List;
-
 import static io.github.mzmine.datamodel.features.types.DataTypes.get;
-import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.AVERAGE;
 import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.MIN;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Retention index type
- * This is frequently rounded, because everyone uses rounded versions
- * Rounding is therefore necessary for the endpoints of ranges to be placed at integer values
  */
 public class RIMinType extends RIType {
 
@@ -50,20 +41,18 @@ public class RIMinType extends RIType {
   @Override
   public String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ri_min";
+    return "retention_index_min";
   }
 
   @Override
   public @NotNull String getHeaderString() {
-    return "Min RI";
+    return "RI (min)";
   }
 
   @NotNull
   @Override
   public List<RowBinding> createDefaultRowBindings() {
-    return List.of(
-      new SimpleRowBinding(this, get(RIType.class), MIN)
-    );
+    return List.of(new SimpleRowBinding(this, get(RIType.class), MIN));
   }
 
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RIType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,43 +25,29 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.MobilityType;
-import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.SimpleRowBinding;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
+import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.AVERAGE;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
-import org.jetbrains.annotations.NotNull;
-
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
-import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.*;
-import static io.github.mzmine.datamodel.features.types.modifiers.BindingsType.MIN;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Retention index type
- * This is frequently rounded, because everyone uses rounded versions
- * Rounding is therefore necessary for the endpoints of ranges to be placed at integer values
  */
 public class RIType extends FloatType {
 
   public RIType() {
-    super(new DecimalFormat("0"));
+    super(new DecimalFormat("0.##"));
   }
 
   @NotNull
   @Override
   public String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ri";
+    return "retention_index";
   }
 
   @Override
@@ -90,28 +76,4 @@ public class RIType extends FloatType {
     return true;
   }
 
-  @Override
-  public Object evaluateBindings(@NotNull BindingsType bindingsType, @NotNull List<? extends ModularDataModel> models) {
-    switch (bindingsType) {
-      case AVERAGE: {
-        // calc average center of ranges
-        float mean = 0.0f;
-        int c = 0;
-        for (var model : models) {
-          Float value = model.get(this);
-          if (value != null) {
-            mean += value;
-            c++;
-          }
-        }
-        return c == 0 ? null : mean / (float) c;
-      }
-      case RANGE:
-        Float max = (Float) evaluateBindings(MAX, models);
-        Float min = (Float) evaluateBindings(MIN, models);
-        return (max != null && min != null) ? max - min : null;
-      default:
-        return super.evaluateBindings(bindingsType, models);
-    }
-  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
@@ -118,6 +118,7 @@ import io.github.mzmine.modules.dataprocessing.id_precursordbsearch.PrecursorDBS
 import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.SpectralLibrarySearchModule;
 import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.library_to_featurelist.SpectralLibraryToFeatureListModule;
 import io.github.mzmine.modules.dataprocessing.norm_linear.LinearNormalizerModule;
+import io.github.mzmine.modules.dataprocessing.norm_ri.RICalculationModule;
 import io.github.mzmine.modules.dataprocessing.norm_rtcalibration.RTCorrectionModule;
 import io.github.mzmine.modules.dataprocessing.norm_standardcompound.StandardCompoundNormalizerModule;
 import io.github.mzmine.modules.io.export_ccsbase.CcsBaseExportModule;
@@ -341,6 +342,7 @@ public class BatchModeModulesList {
           LinearNormalizerModule.class, //
           RTCorrectionModule.class, //
           StandardCompoundNormalizerModule.class, //
+          RICalculationModule.class, //
 
           /*
            * {@link io.github.mzmine.modules.MZmineModuleCategory#FEATURE_GROUPING}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RICalculationModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RICalculationModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,42 +26,31 @@
 package io.github.mzmine.modules.dataprocessing.norm_ri;
 
 import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
-import io.github.mzmine.modules.dataprocessing.norm_ri.RICalculationParameters;
-import io.github.mzmine.modules.dataprocessing.norm_ri.RICalculationTask;
 import io.github.mzmine.modules.impl.TaskPerFeatureListModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.time.Instant;
-
-/**
- * A Module creates tasks which are then added queue
- * <p>
- * 1. add your module to the io.github.mzmine.gui.mainwindow.MainMenu.fmxl
- * <p>
- * 2. for access in batch mode, put your module in the BatchModeModulesList in the package:
- * io.github.mzmine.main
- */
 public class RICalculationModule extends TaskPerFeatureListModule {
 
   public RICalculationModule() {
-    super("Retention index calculation", RICalculationParameters.class, MZmineModuleCategory.NORMALIZATION,
-        false,
+    super("Retention index calculation", RICalculationParameters.class,
+        MZmineModuleCategory.NORMALIZATION, false,
         "This module calculates the Kovats retention indices for gas chromatography.");
   }
 
   @Override
   public @NotNull Task createTask(final @NotNull MZmineProject project,
-                                  final @NotNull ParameterSet parameters, final @NotNull Instant moduleCallDate,
-                                  @Nullable final MemoryMapStorage storage, @NotNull final FeatureList featureList) {
-    return new RICalculationTask(project, storage, moduleCallDate, parameters, (ModularFeatureList) featureList, this.getClass());
+      final @NotNull ParameterSet parameters, final @NotNull Instant moduleCallDate,
+      @Nullable final MemoryMapStorage storage, @NotNull final FeatureList featureList) {
+    return new RICalculationTask(project, storage, moduleCallDate, parameters,
+        (ModularFeatureList) featureList, this.getClass());
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RIScale.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RIScale.java
@@ -1,8 +1,40 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.mzmine.modules.dataprocessing.norm_ri;
 
+import java.time.LocalDate;
 import org.apache.commons.math3.analysis.polynomials.PolynomialSplineFunction;
 
-import java.time.LocalDate;
+/**
+ * Retention index scale
+ *
+ * @param date
+ * @param fileName
+ * @param interpolator
+ */
+public record RIScale(LocalDate date, String fileName, PolynomialSplineFunction interpolator) {
 
-record RIScale(LocalDate date, String fileName, PolynomialSplineFunction interpolator) {
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RITolerance.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RITolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,10 +30,7 @@ import io.github.mzmine.util.RIColumn;
 import io.github.mzmine.util.RIRecord;
 
 /**
- * RTTolerance allows specifying retention time tolerance it is either absolute (seconds or minutes)
- * or relative (percent) but as rest of MZmine codebase, it assumes that rt values (other than the
- * tolerance given in constructor) are in minutes in methods such as getToleranceRange or
- * checkWithinTolerance
+ * RITolerance is an absolute tolerance based on a specific RIColumn
  */
 public class RITolerance {
 
@@ -56,7 +53,8 @@ public class RITolerance {
   public Range<Float> getToleranceRange(final Float riValue) {
     // riValue may not exist depending on alkane scales
     //   Also, averaged RI is zero when riValues do not exist
-    return riValue != null && riValue != 0 ? Range.closed(riValue - tolerance, riValue + tolerance) : Range.all();
+    return riValue != null && riValue != 0 ? Range.closed(riValue - tolerance, riValue + tolerance)
+        : Range.all();
   }
 
   public boolean checkWithinTolerance(Float ri, RIRecord libRI) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RIColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RIColumn.java
@@ -1,12 +1,46 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.mzmine.util;
 
+/**
+ * Order is used to sort records
+ */
 public enum RIColumn {
-    DEFAULT,
-    SEMIPOLAR,
-    NONPOLAR,
-    POLAR;
+  DEFAULT, SEMIPOLAR, NONPOLAR, POLAR;
 
-    public String toString() {
-        return this.name();
-    }
+  public String getShortDefinition() {
+    return switch (this) {
+      case DEFAULT -> "a";
+      case SEMIPOLAR -> "s";
+      case NONPOLAR -> "n";
+      case POLAR -> "p";
+    };
+  }
+
+  public String toString() {
+    return this.name();
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RIRecord.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RIRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,151 +25,128 @@
 
 package io.github.mzmine.util;
 
-import java.util.EnumMap;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
-
 import static java.util.Map.entry;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+/**
+ * This holds information from the RI field in spectral libraries for gas chromatography The RI
+ * field is of form "s=RI/CI/n_samples n=RI/CI/n_samples p=RI/CI/n_samples" (CI denotes confidence
+ * interval) s denotes semipolar, n denotes nonpolar, and p denotes polar If there are 0 samples for
+ * s or n or p, then that part is skipped If there is one sample, then n_samples and CI are skipped
+ * Unclear if non-NIST other formats differ
+ */
+public class RIRecord {
 
-// This holds information from the RI field in spectral libraries for gas chromatography
-//   The RI field is of form "s=RI/CI/n_samples n=RI/CI/n_samples p=RI/CI/n_samples" (CI denotes confidence interval)
-//   s denotes semipolar, n denotes nonpolar, and p denotes polar
-//   If there are 0 samples for s or n or p, then that part is skipped
-//   If there is one sample, then n_samples and CI are skipped
-//   Unclear if non-NIST other formats differ
+  private static final Logger logger = Logger.getLogger(RIRecord.class.getName());
 
+  private static final Map<String, RIColumn> stringsToColumnTypesMap = Map.ofEntries(
+      entry("s=", RIColumn.SEMIPOLAR), entry("SemiStdNP=", RIColumn.SEMIPOLAR),
+      entry("n=", RIColumn.NONPOLAR), entry("StdNP=", RIColumn.NONPOLAR),
+      entry("p=", RIColumn.POLAR), entry("Polar=", RIColumn.POLAR), entry("a=", RIColumn.DEFAULT));
+  
+  // uses list instead of map to lower the memory footprint.
+  // small list with few items is better than hashmap and still fast in lookup
+  private final List<RIRecordPart> records;
 
-public class RIRecord
-{
-    private static final Logger logger = Logger.getLogger(RIRecord.class.getName());
-    private Map<RIColumn, RIRecordPart> map;
-    static private final Map<String, RIColumn> stringsToColumnTypesMap = Map.ofEntries(
-        entry("s=", RIColumn.SEMIPOLAR),
-        entry("SemiStdNP=", RIColumn.SEMIPOLAR),
-        entry("n=", RIColumn.NONPOLAR),
-        entry("StdNP=", RIColumn.NONPOLAR),
-        entry("p=", RIColumn.POLAR),
-        entry("Polar=", RIColumn.POLAR),
-        entry("a=", RIColumn.DEFAULT)
-    );
+  public RIRecord(String record) {
+    this.records = parse(record);
+  }
 
-    public RIRecord(Map<RIColumn, RIRecordPart> map) {
-        this.map = map;
-    }
+  private static List<RIRecordPart> parse(String line) {
+    String[] records = line.split("\\s+");
 
-    public RIRecord(String record) {
-        this.map = parse(record);
-    }
+    ArrayList<RIRecordPart> parsedRecords = new ArrayList<>();
 
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        boolean hasPrev = false;
+    for (String record : records) {
+      try {
+        // Record is just a number, equivalent to a={number}
+        parsedRecords.add(new RIRecordPart(RIColumn.DEFAULT, Float.parseFloat(record), null, null));
+      } catch (NumberFormatException ne) {
+        String discoveredKey = null;
+        RIColumn currentType = null;
 
-        if (map.containsKey(RIColumn.SEMIPOLAR)) {
-            Float s_ri = map.get(RIColumn.SEMIPOLAR).ri();
-            Integer s_count = map.get(RIColumn.SEMIPOLAR).count();
-            Float s_ci = map.get(RIColumn.SEMIPOLAR).ci();
+        for (Map.Entry<String, RIColumn> entry : stringsToColumnTypesMap.entrySet()) {
+          String key = entry.getKey();
+          // Converting keys to lower-case is slower but the map is more readable
+          if (record.toLowerCase().startsWith(key.toLowerCase())) {
+            discoveredKey = key;
+            currentType = entry.getValue();
+            break;
+          }
 
-            // s_ri != null should always be true
-            // round s_ri and s_ci to integer, as that's most likely to be supported
-            sb.append(s_ri != null ? String.format("s=%d", Math.round(s_ri)) : "");
-            sb.append((s_ri != null && s_ci != null && s_count != null ) ? String.format("/%d/%d", Math.round(s_ci), s_count) : "");
-            hasPrev = s_ri != null;
         }
 
-        if (map.containsKey(RIColumn.NONPOLAR)) {
-            Float n_ri = map.get(RIColumn.NONPOLAR).ri();
-            Integer n_count = map.get(RIColumn.NONPOLAR).count();
-            Float n_ci = map.get(RIColumn.NONPOLAR).ci();
+        if (discoveredKey != null) {
+          try {
+            String[] recordValues = record.substring(discoveredKey.length()).split("/");
+            if (recordValues.length > 0) {
+              // RI should never be null
+              final Float ri = recordValues[0] != null ? Float.parseFloat(recordValues[0]) : null;
+              if (ri == null) {
+                continue;
+              }
 
-            // n_ri != null should always be true
-            // round n_ri and n_ci to integer, as that's most likely to be supported
-            sb.append(hasPrev && n_ri != null ? " " : "");
-            sb.append(n_ri != null ? String.format("n=%d", Math.round(n_ri)) : "");
-            sb.append((n_ri != null && n_ci != null && n_count != null ) ? String.format("/%d/%d", Math.round(n_ci), n_count) : "");
-            hasPrev = hasPrev || n_ri != null;
-        }
+              Float ci = null;
+              Integer count = null;
 
-
-        if (map.containsKey(RIColumn.POLAR)) {
-            Float p_ri = map.get(RIColumn.POLAR).ri();
-            Integer p_count = map.get(RIColumn.POLAR).count();
-            Float p_ci = map.get(RIColumn.POLAR).ci();
-
-            // p_ri != null should always be true
-            // round p_ri and p_ci to integer, as that's most likely to be supported
-            sb.append(hasPrev && p_ri != null ? " " : "");
-            sb.append(p_ri != null ? String.format("n=%d", Math.round(p_ri)) : "");
-            sb.append((p_ri != null && p_ci != null&& p_count != null ) ? String.format("/%d/%d", Math.round(p_ci), p_count) : "");
-            hasPrev = hasPrev || p_ri != null;
-        }
-
-        return sb.toString();
-    }
-    private Map<RIColumn, RIRecordPart> parse(String line) {
-        String[] records = line.split("\\s+");
-
-        Map<RIColumn, RIRecordPart> recordsMap = new EnumMap<>(RIColumn.class);
-
-        for(String record : records) {
-            try {
-                // Record is just a number, equivalent to a={number}
-                recordsMap.put(RIColumn.DEFAULT, new RIRecordPart(Float.parseFloat(record), null, null));
-            } catch (NumberFormatException ne)  {
-                String discoveredKey = null;
-                RIColumn currentType = null;
-
-                for (Map.Entry<String, RIColumn> entry : stringsToColumnTypesMap.entrySet()) {
-                    String key = entry.getKey();
-                    // Converting keys to lower-case is slower but the map is more readable
-                    if(record.toLowerCase().startsWith(key.toLowerCase())) {
-                        discoveredKey = key;
-                        currentType = entry.getValue();
-                        break;
-                    }
-
-                }
-
-                if (discoveredKey != null) {
-                    try {
-                        String[] recordValues = record.substring(discoveredKey.length()).split("/");
-                        if (recordValues.length > 0) {
-                            recordsMap.put(currentType, new RIRecordPart(
-                                recordValues[0] != null ? Float.parseFloat(recordValues[0]) : null,
-                                recordValues.length > 2 && recordValues[1] != null && recordValues[2] != null ? Float.parseFloat(recordValues[1]) : null,
-                                recordValues.length > 2 && recordValues[1] != null && recordValues[2] != null ? Integer.parseInt(recordValues[2]) : null));
-                        }
-                    } catch (Exception e) {
-                        logger.warning("Failed to parse RI record: " + line);
-                    }
-                }
-
+              if (recordValues.length > 2 && recordValues[1] != null && recordValues[2] != null) {
+                ci = Float.parseFloat(recordValues[1]);
+                count = Integer.parseInt(recordValues[2]);
+              }
+              parsedRecords.add(new RIRecordPart(currentType, ri, ci, count));
             }
-
-
-
-
-
+          } catch (Exception e) {
+            logger.warning("Failed to parse RI record: " + line);
+          }
         }
-        return recordsMap;
+
+      }
     }
+    parsedRecords.trimToSize(); // save memory
+    // sort to simplify toString
+    parsedRecords.sort(Comparator.comparingInt(p -> p.column.ordinal()));
+    return parsedRecords;
+  }
 
-    public Float getRI(RIColumn type) {
-        if (map.containsKey(type)) {
-            return map.get(type).ri();
-        }
-        else if (map.containsKey(RIColumn.DEFAULT)) {
-            return map.get(RIColumn.DEFAULT).ri();
-        }
-        else {
-            return null;
-        }
-    }
+  public String toString() {
+    // TODO previous implementation did not add the DEFAULT column type to the string. now it does
+    return records.stream().map(RIRecordPart::toString).collect(Collectors.joining(" "));
+  }
 
-    protected record RIRecordPart(Float ri, Float ci, Integer count) {
+  public Float getRI(RIColumn type) {
+    int defaultIndex = -1;
+    for (int i = 0; i < records.size(); i++) {
+      final RIRecordPart part = records.get(i);
+      if (part.column == type) {
+        return part.ri();
+      } else if (part.column == RIColumn.DEFAULT) {
+        defaultIndex = i;
+      }
     }
+    return defaultIndex == -1 ? null : records.get(defaultIndex).ri();
+  }
+
+  /**
+   * @param ri
+   * @param ci    confidence interval
+   * @param count
+   */
+  protected record RIRecordPart(RIColumn column, float ri, Float ci, Integer count) {
+
+    @Override
+    public String toString() {
+      String base = "%s=%f".formatted(column.getShortDefinition(), ri);
+      if (ci != null && count != null) {
+        return base + "/%f/%d".formatted(ci, count);
+      }
+      return base;
+    }
+  }
 
 }
 


### PR DESCRIPTION
I simplified the RIRecord class. The toString was not handling the default column was that intended? 
You can run the module with the quick access when you hit CTRL + F or double shift key on your keyboard.
